### PR TITLE
Improve download button UX to prevent layout shifts

### DIFF
--- a/components/ImageMosaic.vue
+++ b/components/ImageMosaic.vue
@@ -78,8 +78,9 @@
           元に戻す
         </button>
         <button
-          v-if="processedImage"
+          v-if="uploadedImage"
           class="btn btn-success"
+          :disabled="!processedImage"
           @click="downloadImage"
         >
           ダウンロード
@@ -700,8 +701,14 @@ onMounted(() => {
   color: white;
 }
 
-.btn-success:hover {
+.btn-success:hover:not(:disabled) {
   background-color: #1e7e34;
+}
+
+.btn-success:disabled {
+  background-color: #ccc;
+  color: #666;
+  cursor: not-allowed;
 }
 
 .btn-info {


### PR DESCRIPTION
## Summary
- Improved download button behavior to prevent layout shifts during image processing
- Download button now shows immediately when image is uploaded but remains disabled until processing is complete
- Added proper disabled styling for better visual feedback

## Changes
- Modified download button to use `v-if="uploadedImage"` instead of `v-if="processedImage"`
- Added `:disabled="\!processedImage"` to prevent clicks before processing
- Enhanced CSS with disabled state styling for consistent user experience

## Test plan
- [x] Upload an image and verify download button appears immediately
- [x] Verify button is disabled (grayed out) before any processing
- [x] Process a region and verify button becomes active
- [x] Verify no layout shifts occur during the workflow

🤖 Generated with [Claude Code](https://claude.ai/code)