### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint & Format Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/kiakiraki/cnsr/security/code-scanning/1](https://github.com/kiakiraki/cnsr/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Since the workflow only performs read operations (e.g., checking out code, installing dependencies, running tests), the `contents: read` permission is sufficient.

The `permissions` block should be added immediately after the `name` field at the top of the file. This ensures that the workflow explicitly limits the permissions of the `GITHUB_TOKEN` to the least privilege required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
