### PR TITLE
fix: prevent rectangle selection on right-click

### DIFF
--- a/components/ImageMosaic.vue
+++ b/components/ImageMosaic.vue
@@ -333,6 +333,11 @@ const startSelection = (event: MouseEvent | TouchEvent) => {
   event.preventDefault()
   if (!canvas.value) return
 
+  // Prevent selection on right-click
+  if (event instanceof MouseEvent && event.button === 2) {
+    return
+  }
+
   // Ensure canvas metrics are fresh for mouse events at selection start
   if (event instanceof MouseEvent) {
     updateCanvasMetrics()


### PR DESCRIPTION
## Summary
- Add right-click detection in startSelection function to prevent unwanted rectangle selection
- Return early when right mouse button (button === 2) is pressed
- Improves user experience by avoiding accidental selections when right-clicking on images

## Test plan
- [x] Build passes successfully
- [x] Lint and format checks pass
- [ ] Manual testing: Right-click on image should not start rectangle selection
- [ ] Manual testing: Left-click still works for rectangle selection
- [ ] Manual testing: Touch events still work on mobile devices

🤖 Generated with [Claude Code](https://claude.ai/code)