### PR TITLE
Add Serena MCP memory files for project documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ logs
 .env
 .env.*
 !.env.example
+
+# Serena MCP cache files
+.serena/cache/

--- a/.serena/memories/code_style_and_conventions.md
+++ b/.serena/memories/code_style_and_conventions.md
@@ -1,0 +1,47 @@
+# Code Style & Conventions
+
+## Formatting (Prettier Configuration)
+
+- **Semicolons**: Disabled (`"semi": false`)
+- **Quotes**: Single quotes (`"singleQuote": true`)
+- **Tab Width**: 2 spaces (`"tabWidth": 2`)
+- **Trailing Commas**: ES5 style (`"trailingComma": "es5"`)
+- **Print Width**: 80 characters (`"printWidth": 80`)
+- **Bracket Spacing**: Enabled (`"bracketSpacing": true`)
+- **Arrow Function Parentheses**: Avoid when possible (`"arrowParens": "avoid"`)
+- **Vue Files**: No indentation for script/style blocks (`"vueIndentScriptAndStyle": false`)
+
+## ESLint Configuration
+
+- **Base Config**: @nuxt/eslint-config with flat config format
+- **Stylistic Rules**: Disabled (`features.stylistic: false`)
+- **Vue Specific**: HTML self-closing tags disabled (`'vue/html-self-closing': 'off'`)
+
+## Vue.js Conventions
+
+- **Composition API**: Exclusively used throughout the codebase
+- **TypeScript**: Full type annotations and interface definitions
+- **Reactivity**: `ref()`, `computed()`, `reactive()` patterns
+- **Lifecycle**: `onMounted()`, `onUnmounted()` hooks
+- **Component Structure**: Single-file components (.vue) with clear separation
+
+## Naming Conventions
+
+- **Variables**: camelCase (e.g., `currentImage`, `processingMode`)
+- **Constants**: UPPER_SNAKE_CASE (e.g., `MAX_UNDO_LEVELS`, `THROTTLE_INTERVAL`)
+- **Functions**: camelCase with descriptive names (e.g., `loadImageToCanvas`, `getEventPosition`)
+- **Interfaces**: PascalCase (e.g., `SelectionArea`)
+
+## File Organization
+
+- **Components**: `/components/` directory
+- **Tests**: `/test/` directory with descriptive names
+- **Configuration**: Root-level config files
+- **Public Assets**: `/public/` directory
+
+## Testing Patterns
+
+- **Test Files**: `.test.ts` extension
+- **Test Structure**: `describe()` blocks with descriptive names
+- **Mocking**: Comprehensive mocks for browser APIs
+- **Test Cases**: Edge cases and error conditions covered

--- a/.serena/memories/codebase_structure.md
+++ b/.serena/memories/codebase_structure.md
@@ -1,0 +1,70 @@
+# Codebase Structure & Architecture
+
+## Directory Layout
+
+```
+├── components/
+│   └── ImageMosaic.vue          # Main image processing component
+├── test/                        # Test suite
+│   ├── coordinate-calculation.test.ts
+│   ├── state-management.test.ts
+│   ├── undo-functionality.test.ts
+│   ├── download-functionality.test.ts
+│   └── setup.ts                 # Test configuration & mocks
+├── public/                      # Static assets
+│   ├── favicon.ico
+│   ├── favicon.png
+│   └── robots.txt
+├── server/                      # Server-side code (minimal)
+│   └── tsconfig.json
+├── .github/                     # GitHub Actions & Dependabot
+│   ├── workflows/lint.yml
+│   └── dependabot.yml
+├── app.vue                      # Root component
+├── nuxt.config.ts              # Nuxt configuration
+├── package.json                # Dependencies & scripts
+├── tsconfig.json               # TypeScript configuration
+├── vitest.config.ts            # Test runner configuration
+├── eslint.config.js            # Linting rules
+├── .prettierrc                 # Code formatting rules
+├── wrangler.toml               # Cloudflare deployment config
+├── CLAUDE.md                   # Development instructions
+└── README.md                   # Project documentation
+```
+
+## Core Component Architecture
+
+### ImageMosaic.vue
+
+The main component contains extensive functionality:
+
+- **File Handling**: Upload, drag-drop, paste operations
+- **Canvas Management**: Image rendering, scaling, coordinate calculations
+- **Processing Operations**: Mosaic, black/white fill implementations
+- **Selection System**: Mouse/touch-based area selection
+- **State Management**: Undo stack (64 levels), processing modes
+- **Download System**: PNG export functionality
+
+### Key Functions & Properties
+
+- `uploadedImage`: Current loaded image state
+- `processingMode`: Current operation mode (mosaic/black/white)
+- `undoStack`: Array maintaining processing history
+- `selection`: Current selection coordinates
+- `getEventPosition()`: Coordinate transformation function
+- `applyMosaic()`: Core processing function
+- `downloadImage()`: Export functionality
+
+## Configuration Files
+
+### Nuxt Configuration
+
+- **SSR Disabled**: `ssr: false` for client-side only operation
+- **Cloudflare Pages**: Optimized for edge deployment
+- **TypeScript**: Full TypeScript integration
+
+### Test Configuration
+
+- **Vitest**: Modern test runner with jsdom
+- **Comprehensive Mocks**: Canvas, FileReader, Image, Touch APIs
+- **Global Setup**: Browser API simulation for testing

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,30 @@
+# CNSR - Image Mosaic Processing Application
+
+## Project Purpose
+
+CNSR is a privacy protection web application built with Nuxt.js/Vue.js that allows users to upload images and apply mosaic, black fill, or white fill processing to selected regions. It's designed as a client-side tool for protecting sensitive information in images.
+
+## Key Features
+
+- **Image Upload**: Drag & drop, click, and Ctrl+V (paste) support
+- **Processing Modes**: Mosaic (pixelization), black fill, white fill
+- **Region Selection**: Mouse/touch-based area selection
+- **Undo Functionality**: Up to 64 levels of undo
+- **Image Download**: PNG format export
+- **Responsive Design**: Mobile and desktop support
+- **Dark Mode**: Automatic system preference detection
+
+## Technical Architecture
+
+- **Framework**: Nuxt.js 4.0.3 with SSR disabled (`ssr: false`)
+- **Language**: TypeScript with Vue 3 Composition API
+- **Canvas API**: Heavy use of HTML5 Canvas for image processing
+- **Client-Side Only**: No server-side processing for privacy
+- **Deployment**: Cloudflare Pages with static generation
+- **State Management**: Vue 3 reactive refs and computed properties
+
+## Core Components
+
+- `app.vue`: Root application component
+- `components/ImageMosaic.vue`: Main image processing component with Canvas operations
+- Comprehensive test suite covering coordinate calculations, state management, and undo functionality

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,64 @@
+# Essential Development Commands
+
+## Development Server
+
+```bash
+npm run dev
+# Starts development server on http://localhost:3000
+```
+
+## Testing
+
+```bash
+npm run test
+# Runs tests in watch mode with Vitest
+
+npm run test:run
+# Runs tests once (for CI/production)
+```
+
+## Code Quality & Formatting
+
+```bash
+npm run lint
+# Runs ESLint to check for code issues
+
+npm run lint:fix
+# Runs ESLint with automatic fixing
+
+npm run format
+# Formats code with Prettier
+
+npm run format:check
+# Checks if code is properly formatted (for CI)
+```
+
+## Build & Production
+
+```bash
+npm run build
+# Creates production build for deployment
+
+npm run preview
+# Previews production build locally
+
+npm run generate
+# Generates static files (same as build for this project)
+```
+
+## Package Management
+
+```bash
+npm install
+# Installs dependencies
+
+npm run postinstall
+# Prepares Nuxt (runs automatically after install)
+```
+
+## System Commands (Linux)
+
+- **File Operations**: `ls`, `find`, `grep` (prefer rg/ripgrep), `cat`, `head`, `tail`
+- **Git Operations**: `git status`, `git add`, `git commit`, `git push`, `git pull`
+- **Process Management**: `ps`, `kill`, `killall`
+- **Text Processing**: `sed`, `awk`, `cut`, `sort`, `uniq`

--- a/.serena/memories/task_completion_checklist.md
+++ b/.serena/memories/task_completion_checklist.md
@@ -1,0 +1,61 @@
+# Task Completion Checklist
+
+## Code Quality Requirements
+
+When completing any development task, ensure the following steps are executed:
+
+### 1. Linting & Formatting
+
+```bash
+npm run lint
+# Must pass without errors
+
+npm run format:check
+# Must pass formatting validation
+```
+
+### 2. Testing
+
+```bash
+npm run test:run
+# All tests must pass
+# Add new tests for new functionality
+```
+
+### 3. Build Verification
+
+```bash
+npm run build
+# Must complete successfully without errors
+# Verifies TypeScript compilation and bundling
+```
+
+## Pre-Commit Requirements
+
+- **ESLint**: No linting errors allowed
+- **Prettier**: Code must be properly formatted
+- **TypeScript**: No type errors
+- **Tests**: All existing tests must pass
+- **Build**: Production build must succeed
+
+## CI/CD Pipeline
+
+The GitHub Actions workflow automatically runs:
+
+1. ESLint checking (`npm run lint`)
+2. Prettier format checking (`npm run format:check`)
+3. Test execution (`npm run test:run`)
+4. Build verification (`npm run build`)
+
+## Testing Guidelines
+
+- **Unit Tests**: Required for new functions and components
+- **Edge Cases**: Test boundary conditions and error scenarios
+- **Canvas Operations**: Mock Canvas API interactions properly
+- **Touch Events**: Ensure mobile compatibility testing
+
+## Documentation Updates
+
+- Update CLAUDE.md if architectural changes are made
+- Maintain README.md for user-facing changes
+- Update component documentation for significant modifications

--- a/.serena/memories/tech_stack_and_dependencies.md
+++ b/.serena/memories/tech_stack_and_dependencies.md
@@ -1,0 +1,38 @@
+# Technology Stack & Dependencies
+
+## Core Framework & Runtime
+
+- **Nuxt.js**: 4.0.3 (SSR disabled for client-side processing)
+- **Vue.js**: 3.5.17 with Composition API
+- **Vue Router**: 4.5.1
+- **TypeScript**: Full TypeScript support with strict typing
+
+## Development & Build Tools
+
+- **Vite**: Build tool and dev server (via Nuxt)
+- **Vitest**: 3.2.4 for unit testing with jsdom environment
+- **Vue Test Utils**: 2.4.6 for component testing
+- **ESLint**: 9.33.0 with @nuxt/eslint-config 1.9.0
+- **Prettier**: 3.6.2 for code formatting
+- **TypeScript ESLint**: 8.40.0 for TS-specific linting
+
+## Testing & Quality Assurance
+
+- **Test Environment**: jsdom for DOM simulation
+- **Test Setup**: Comprehensive mocks for Canvas API, FileReader, Image, TouchEvent
+- **Coverage Areas**: Coordinate calculations, state management, undo functionality, download features
+- **CI/CD**: GitHub Actions for automated linting, formatting checks, testing, and builds
+
+## Deployment & Hosting
+
+- **Target Platform**: Cloudflare Pages
+- **Build Mode**: Static generation (`target: 'static'`)
+- **Nitro Preset**: `cloudflare-pages`
+- **Node.js Version**: 20 (as specified in CI)
+
+## Browser APIs Used
+
+- **Canvas API**: Core image processing operations
+- **File API**: Image upload and processing
+- **Touch API**: Mobile device support
+- **URL API**: Object URL creation for downloads

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,67 @@
+# language of the project (csharp, python, rust, java, typescript, go, cpp, or ruby)
+#  * For C, use cpp
+#  * For JavaScript, use typescript
+# Special requirements:
+#  * csharp: Requires the presence of a .sln file in the project folder.
+language: typescript
+
+# whether to use the project's gitignore file to ignore files
+# Added on 2025-04-07
+ignore_all_files_in_gitignore: true
+# list of additional paths to ignore
+# same syntax as gitignore, so you can use * and **
+# Was previously called `ignored_dirs`, please update your config if you are using that.
+# Added (renamed) on 2025-04-07
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions,
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project by name.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_lines`: Deletes a range of lines within a file.
+#  * `delete_memory`: Deletes a memory from Serena's project-specific memory store.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_referencing_code_snippets`: Finds code snippets in which the symbol at the given location is referenced.
+#  * `find_referencing_symbols`: Finds symbols that reference the symbol at the given location (optionally filtered by type).
+#  * `find_symbol`: Performs a global (or local) search for symbols with/containing a given name/substring (optionally filtered by type).
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Gets the initial instructions for the current project.
+#     Should only be used in settings where the system prompt cannot be set,
+#     e.g. in clients you have no control over, like Claude Desktop.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_at_line`: Inserts content at a given line in a file.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: Lists memories in Serena's project-specific memory store.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `prepare_for_new_conversation`: Provides instructions for preparing for a new conversation (in order to continue with the necessary context).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Reads the memory with the given name from Serena's project-specific memory store.
+#  * `remove_project`: Removes a project from the Serena configuration.
+#  * `replace_lines`: Replaces a range of lines within a file with new content.
+#  * `replace_symbol_body`: Replaces the full definition of a symbol.
+#  * `restart_language_server`: Restarts the language server, may be necessary when edits not through Serena happen.
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `summarize_changes`: Provides instructions for summarizing the changes made to the codebase.
+#  * `switch_modes`: Activates modes by providing a list of their names
+#  * `think_about_collected_information`: Thinking tool for pondering the completeness of collected information.
+#  * `think_about_task_adherence`: Thinking tool for determining whether the agent is still on track with the current task.
+#  * `think_about_whether_you_are_done`: Thinking tool for determining whether the task is truly completed.
+#  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
+excluded_tools: []
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ''
+
+project_name: 'cnsr'


### PR DESCRIPTION
## Summary
• Add comprehensive Serena MCP memory files for CNSR project documentation
• Update .gitignore to exclude Serena cache files from version control
• Enable Serena MCP server to understand project architecture and development workflow

## Changes
- **Project Overview**: Core purpose, features, and technical architecture
- **Tech Stack Documentation**: Dependencies, frameworks, and deployment setup  
- **Code Style Guide**: Prettier/ESLint rules and Vue.js conventions
- **Development Commands**: Essential npm scripts and system commands
- **Task Completion Checklist**: Quality requirements and CI/CD pipeline
- **Codebase Structure**: Directory layout and component documentation
- **Updated .gitignore**: Exclude `.serena/cache/` files

## Test plan
- [x] Memory files successfully created with comprehensive project information
- [x] Cache files properly excluded from version control
- [x] No build or linting errors introduced
- [x] Serena MCP server can access and utilize project documentation

🤖 Generated with [Claude Code](https://claude.ai/code)