### PR TITLE
chore: align versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Vue.js/Nuxt.jsで構築された画像処理Webアプリケーションです。
 
 ## 技術スタック
 
-- **フレームワーク**: Nuxt.js 3.17.6
+- **フレームワーク**: Nuxt.js 4.0.3
 - **言語**: TypeScript, Vue 3 Composition API
 - **テスト**: Vitest + Vue Test Utils
 - **リンター**: ESLint + Prettier

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -22,5 +22,4 @@ export default defineNuxtConfig({
   nitro: {
     preset: 'cloudflare-pages',
   },
-  target: 'static',
 })

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,7 +3,7 @@ command = "npm run build"
 publish = "dist"
 
 [build.environment]
-NODE_VERSION = "18"
+NODE_VERSION = "20"
 
 [[headers]]
 for = "/*"


### PR DESCRIPTION
- README: Nuxt 3.17.6 -> 4.0.3
- wrangler: NODE_VERSION 18 -> 20 (match CI)
- nuxt.config: remove deprecated target: 'static' for Nuxt 4

This PR aligns versions across docs and configs for consistency.