### PR TITLE
chore(deps): group dependabot updates to reduce PR noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,50 @@
 
 version: 2
 updates:
-  - package-ecosystem: 'npm' # See documentation for possible values
-    directory: '/' # Location of package manifests
+  - package-ecosystem: 'npm'
+    directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      nuxt-vue:
+        patterns:
+          - 'nuxt'
+          - 'nuxt-*'
+          - '@nuxt/*'
+          - 'vue'
+          - 'vue-*'
+          - '@vue/*'
+          - '@vitejs/plugin-vue'
+        update-types:
+          - 'minor'
+          - 'patch'
+      lint-format:
+        patterns:
+          - 'eslint'
+          - 'eslint-*'
+          - '@typescript-eslint/*'
+          - 'prettier'
+        update-types:
+          - 'minor'
+          - 'patch'
+      test:
+        patterns:
+          - 'vitest'
+          - 'jsdom'
+        update-types:
+          - 'minor'
+          - 'patch'
+      dev-minor:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
+
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    groups:
+      actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## Summary
- `.github/dependabot.yml` に `groups` を追加し、minor/patch 更新を束ねて PR 数を削減
- Nuxt/Vue 系・Lint/Format 系・テスト系・その他 devDeps をテーマ別にグルーピング
- major アップデートは引き続き個別 PR（破壊的変更を分離して安全にレビュー可能に）

## グループ構成
| グループ | 対象 | 範囲 |
| --- | --- | --- |
| `nuxt-vue` | `nuxt`, `nuxt-*`, `@nuxt/*`, `vue`, `vue-*`, `@vue/*`, `@vitejs/plugin-vue` | minor + patch |
| `lint-format` | `eslint`, `eslint-*`, `@typescript-eslint/*`, `prettier` | minor + patch |
| `test` | `vitest`, `jsdom` | minor + patch |
| `dev-minor` | 上記以外の devDependencies（`commander` 等） | minor + patch |
| `actions` | GitHub Actions 全般 | 全更新 |

セキュリティアラート起因の更新は Dependabot の仕様によりグループ化を無視して個別 PR が立つため、緊急対応が埋もれない設計です。

## Test plan
- [ ] PR マージ後、Dependabot の次回スケジュール実行（weekly）で grouped PR が作成されることを確認
- [ ] grouped PR の CI（lint）が通ることを確認
- [ ] 必要に応じて `dependabot.com` ダッシュボードで設定がパースできているか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)